### PR TITLE
Several hotfixes.

### DIFF
--- a/src/Consolly.php
+++ b/src/Consolly.php
@@ -152,6 +152,7 @@ class Consolly
         $this->defaultCommand = $defaultCommand;
         $this->source = $source;
         $this->distributor = $distributor;
+        $this->commands = [];
     }
 
     /**

--- a/src/Distributor/Distributor.php
+++ b/src/Distributor/Distributor.php
@@ -43,7 +43,7 @@ class Distributor implements DistributorInterface
      */
     public function __construct()
     {
-        $this->commandPosition = -1;
+        $this->commandPosition = 0;
     }
 
     /**
@@ -305,32 +305,6 @@ class Distributor implements DistributorInterface
      */
     public function getNextArguments(): array
     {
-        if ($this->commandPosition === -1) {
-            $commandMethodName = 'getCommand()';
-            $className = Distributor::class;
-            $commandPosition = '$commandPosition';
-            $nextArgumentsMethod = 'getNextArguments()';
-
-            throw new LogicException(
-                sprintf(
-                    'Command position is -1. ' .
-                    'This exception should not be thrown because the %s method of the "%s" class ' .
-                    'sets %s to another value. This is only possible if you extend the "%s" class ' .
-                    'by overriding the %s method and leaving the default value of the %s variable. ' .
-                    'To fix this you should set the %s variable in the %s method or override the %s method. ',
-                    $commandMethodName,
-                    $className,
-                    $commandPosition,
-                    $className,
-                    $commandMethodName,
-                    $commandPosition,
-                    $commandPosition,
-                    $commandMethodName,
-                    $nextArgumentsMethod
-                )
-            );
-        }
-
         return array_slice($this->arguments, $this->commandPosition + 1);
     }
 }

--- a/tests/ConsollyTest.php
+++ b/tests/ConsollyTest.php
@@ -29,12 +29,25 @@ class ConsollyTest extends TestCase
             [
                 [
                     'unknown-command'
-                ], new DefaultTestCommand()
+                ], new DefaultTestCommand(), true
+            ],
+            [
+                [
+                    'unknown-command'
+                ], new DefaultTestCommand(), false
             ],
             [
                 [
                     ''
-                ], null
+                ], null, false
+            ],
+            [
+                [
+                ], new TestCommand(), false
+            ],
+            [
+                [
+                ], new TestCommand(), true
             ]
         ];
     }
@@ -48,9 +61,11 @@ class ConsollyTest extends TestCase
      *
      * @param CommandInterface|null $defaultCommand
      *
+     * @param bool $addCommand
+     *
      * @throws CommandNotFoundException
      */
-    public function testDefaultCommand(array $arguments, ?CommandInterface $defaultCommand): void
+    public function testDefaultCommand(array $arguments, ?CommandInterface $defaultCommand, bool $addCommand): void
     {
         if (is_null($defaultCommand)) {
             $this->expectException(CommandNotFoundException::class);
@@ -62,7 +77,9 @@ class ConsollyTest extends TestCase
             $defaultCommand
         );
 
-        $consolly->addCommand(new TestCommand());
+        if ($addCommand) {
+            $consolly->addCommand(new TestCommand());
+        }
 
         self::assertTrue($consolly->handle());
     }


### PR DESCRIPTION
Fixes:
- Fixed useless LogicException thrown in the distributor's getNextArguments method after the distributor received an empty array of commands.
- Fixed uninitialized variable $commands in Consolly class.

Other
- Added regression tests for the cases described above.